### PR TITLE
fix: validate tokenized urls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -402,7 +402,7 @@ jobs:
       - name: Setup test branch
         id: setup-test-branch
         run: |
-          BRANCH_NAME="test_on_remote-$(date +%s)"
+          BRANCH_NAME="test_token_url-$(date +%s)"
 
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -393,3 +393,49 @@ jobs:
           fi
 
           echo "Validation passed: changedFilesIfAvailable is $changedFilesIfAvailable."
+  test-token-url: # make sure the action works on a clean machine without building
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - name: Setup test branch
+        id: setup-test-branch
+        run: |
+          BRANCH_NAME="test_on_remote-$(date +%s)"
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global url.https://x-access-token:${{ inputs.token }}@github.com/.insteadOf https://github.com/
+
+          git checkout -b $BRANCH_NAME
+          git push --set-upstream origin $BRANCH_NAME
+
+          git status --porcelain=v2 --branch --untracked-files=no
+
+          echo $BRANCH_NAME > "test-file.txt"
+          echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      - uses: ./
+        id: test-action
+        with:
+          token: ${{ github.token }}
+          stage-all-files: true
+          commit-message: ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Delete test branch
+        run: |
+          git push --force --delete origin ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Check output
+        run: |
+          changedFilesIfAvailable=$(echo '${{ steps.test-action.outputs.commit-response }}' | jq -r '.data.createCommitOnBranch.commit.changedFilesIfAvailable')
+
+          if [[ -z "$changedFilesIfAvailable" || "$changedFilesIfAvailable" == "null" ]]; then
+            echo "Error: changedFilesIfAvailable is empty or null. Verify the output from test-action."
+            exit 1
+          fi
+
+          if [[ "$changedFilesIfAvailable" -ne 1 ]]; then
+            echo "Error: changedFilesIfAvailable is expected to be 1 but got $changedFilesIfAvailable."
+            exit 1
+          fi
+
+          echo "Validation passed: changedFilesIfAvailable is $changedFilesIfAvailable."

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "Remote URL: $REMOTE_URL"
 
         # Parse the owner and repo using regex
-        if [[ "$REMOTE_URL" =~ (git@|https://)github\.com[:/](.+)/(.+?)(\.git)?$ ]]; then
+        if [[ "$REMOTE_URL" =~ (.*?)github\.com[:/](.+)/(.+?)(\.git)?$ ]]; then
           OWNER=${BASH_REMATCH[2]}
           REPO=${BASH_REMATCH[3]}
           BRANCH=$(git branch --show-current)


### PR DESCRIPTION
- Allow for urls that are prefixed with more than just `git@` or `https://` Fixes an issue where a URL with authorization doesn't validate. E.g. `https://x-access-token:asdfasdf@github.com/my/repo`