### PR TITLE
Improve support for larger commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,9 +229,20 @@ jobs:
 
           git checkout -b $BRANCH_NAME
           git push --set-upstream origin $BRANCH_NAME
-          
-          echo $BRANCH_NAME > "test-file1.txt"
-          echo $BRANCH_NAME > "test-file2.txt"
+
+          file_content="$(mktemp temp-random-file-XXXXXX)"
+          # generate a file with 500KB of As
+          yes A | head -c 500000 > "$file_content"
+
+          for i in {1..10}
+          do
+              cp "$file_content" "test-file$i.txt"
+              echo "test-file$i.txt size: $(stat -c '%s' test-file$i.txt)"
+          done
+
+          # remove the temp file as we don't want to commit it
+          rm "$file_content"
+
           
           git add .
           
@@ -257,12 +268,124 @@ jobs:
             exit 1
           fi
 
-          if [[ "$changedFilesIfAvailable" -ne 2 ]]; then
-            echo "Error: changedFilesIfAvailable is expected to be 2 but got $changedFilesIfAvailable."
+          if [[ "$changedFilesIfAvailable" -ne 10 ]]; then
+            echo "Error: changedFilesIfAvailable is expected to be 10 but got $changedFilesIfAvailable."
             exit 1
           fi
 
           echo "Validation passed: changedFilesIfAvailable is $changedFilesIfAvailable."
+
+  test-very-large-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+      - name: Setup test branch
+        id: setup-test-branch
+        run: |
+          BRANCH_NAME="test_very_large_file-$(date +%s)"
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout -b $BRANCH_NAME
+          git push --set-upstream origin $BRANCH_NAME
+
+          # generate a file with 25MB of As
+          yes A | head -c 25000000 >  test-file.txt
+          echo "test-file.txt size: $(stat -c '%s' test-file.txt)"
+
+          git add .
+
+          git status --porcelain=v2 --branch --untracked-files=no
+
+          echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      - uses: ./
+        id: test-action
+        with:
+          token: ${{ github.token }}
+          stage-all-files: false
+          commit-message: ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Delete test branch
+        run: |
+          git push --force --delete origin ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Check output
+        run: |
+          changedFilesIfAvailable=$(echo '${{ steps.test-action.outputs.commit-response }}' | jq -r '.data.createCommitOnBranch.commit.changedFilesIfAvailable')
+
+          if [[ -z "$changedFilesIfAvailable" || "$changedFilesIfAvailable" == "null" ]]; then
+            echo "Error: changedFilesIfAvailable is empty or null. Verify the output from test-action."
+            exit 1
+          fi
+
+          if [[ "$changedFilesIfAvailable" -ne 1 ]]; then
+            echo "Error: changedFilesIfAvailable is expected to be 1 but got $changedFilesIfAvailable."
+            exit 1
+          fi
+
+          echo "Validation passed: changedFilesIfAvailable is $changedFilesIfAvailable."
+
+  test-multiple-large-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+      - name: Setup test branch
+        id: setup-test-branch
+        run: |
+          BRANCH_NAME="test_multiple_large_files-$(date +%s)"
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout -b $BRANCH_NAME
+          git push --set-upstream origin $BRANCH_NAME
+
+          large_file="$(mktemp temp-random-file-XXXXXX)"
+          # generate a file with 2.5MB of As
+          yes A | head -c 2500000 > "$large_file"
+
+          for i in {1..10}
+          do
+              cp "$large_file" "test-file$i.txt"
+              echo "test-file$i.txt size: $(stat -c '%s' test-file$i.txt)"
+          done
+
+          # remove the temp file as we don't want to commit it
+          rm "$large_file"
+
+          git add .
+
+          git status --porcelain=v2 --branch --untracked-files=no
+
+          echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      - uses: ./
+        id: test-action
+        with:
+          token: ${{ github.token }}
+          stage-all-files: false
+          commit-message: ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Delete test branch
+        run: |
+          git push --force --delete origin ${{ steps.setup-test-branch.outputs.branch-name }}
+      - name: Check output
+        run: |
+          changedFilesIfAvailable=$(echo '${{ steps.test-action.outputs.commit-response }}' | jq -r '.data.createCommitOnBranch.commit.changedFilesIfAvailable')
+
+          if [[ -z "$changedFilesIfAvailable" || "$changedFilesIfAvailable" == "null" ]]; then
+            echo "Error: changedFilesIfAvailable is empty or null. Verify the output from test-action."
+            exit 1
+          fi
+
+          if [[ "$changedFilesIfAvailable" -ne 10 ]]; then
+            echo "Error: changedFilesIfAvailable is expected to be 10 but got $changedFilesIfAvailable."
+            exit 1
+          fi
+
+          echo "Validation passed: changedFilesIfAvailable is $changedFilesIfAvailable."
+        
   test-file-rename: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Example how to use GitHub app installation token
 - The branch that is checked out needs to be in an attached state. Meaning that you can commit and push to it
 - Currently, the action only supports adding, updating, and deleting files. It doesn't reconstruct the entire tree for
   commit. Moving files would succeed, but the old file will still remain in its location.
+- The cumulative size of modified files cannot be bigger than 40MB due to GitHub API limits. Note that contents of deleted files are not considered for this limit.
 
 # (Legacy) GitHub Api Commit
 

--- a/action.yml
+++ b/action.yml
@@ -110,10 +110,15 @@ runs:
         done <<< "$status_output"
         echo ""
 
+        contents_dir="$(mktemp -d)"
+        echo "contents_dir=$contents_dir" >> $GITHUB_OUTPUT
+
         additions=""
         for filepath in "${staged_additions[@]}"; do
-          file_content=$(cat "$filepath" | base64 | tr -d '\n') # Encode file content in Base64
-          additions+=" -F \"fileAdditions[][path]=$filepath\" -F \"fileAdditions[][contents]=$file_content\" "
+          contents_file="$(mktemp --tmpdir=$contents_dir temp-file-XXXXXX)"
+          cat "$filepath" | base64 | tr -d '\n' > "$contents_file" # Encode file content in Base64
+
+          additions+=" -F \"fileAdditions[][path]=$filepath\" -F \"fileAdditions[][contents]=@$contents_file\" "
         done
       
         deletions=""
@@ -185,5 +190,8 @@ runs:
         
         response=$(gh api graphql -F "expectedHeadOid=$head_oid" ${{ steps.additions-and-deletions.outputs.additions }} ${{ steps.additions-and-deletions.outputs.deletions }} -F "query=$graphql_query")
         echo "commit_response=$response" >> $GITHUB_OUTPUT
+
+        # Clean up temporary files
+        rm -rf "${{ steps.additions-and-deletions.outputs.contents_dir }}"
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## WHAT
Change graphql call to read file contents from the file system instead of passing it in directly as part of the CLI option.

## WHY
GitHub workflows templating has a limitation on the amount of memory that is available. When passing in the file contents as part of the CLI option via GitHub workflows templating this limit is hit relatively quickly, if cumulative file content gets bigger than a few KB.

This template memory error can be seen in 3 tests of the below workflow run. Note that the modified multiple files test only writes a total of 5MB and already fails.

- https://github.com/max-frank/github-api-commit-action/actions/runs/14144929394/job/39631093866

Additionally the shell also has its own argument size limit, which is quickly hit as well.
Both of these limits can be avoided by populating the file contents field values from the file system instead.

## Note

A third limit exists which is the maximum commit size that the GitHub GraphQL API can handle. This limit seems to be at 40MB (40MiB will already fail). So the cumulative size of all files modified, added or renamed must be below this limit for commits created via the GraphQL API.