### PR TITLE
fix: test workflow use default checkout ref for pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -57,8 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -102,8 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -151,8 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -201,8 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -250,8 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -299,8 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -348,8 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |
@@ -397,8 +389,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.head_ref || github.ref }}
+
       - name: Setup test branch
         id: setup-test-branch
         run: |

--- a/.github/workflows/update-major-release-tag.yml
+++ b/.github/workflows/update-major-release-tag.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get major version num and update tag
         run: |


### PR DESCRIPTION
- Allows actions/checkout to use the default ref for the pull request. This should hopefully allow forked contribution runs to succeed in checking out the code for test run.