### PR TITLE
chore: update workflows with secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: 'Test'
 on: # rebuild any PRs and main branch changes
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update_changelog:
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
@@ -55,12 +56,26 @@ jobs:
         id: cpr
         run: |
           PR_URL=$(gh pr create --title "chore: update changelog [bot]" --body "PR created automatically through update-changelog.yml workflow")
+          gh pr merge --auto --squash "$PR_URL"
           echo "PR_URL=$PR_URL" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Approve and auto-merge
-        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=helper-bot:app-id
+            GITHUB_APP_PRIVATE_KEY=helper-bot:private-key
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{steps.cpr.outputs.PR_URL}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-major-release-tag.yml
+++ b/.github/workflows/update-major-release-tag.yml
@@ -11,13 +11,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=helper-bot:app-id
+            GITHUB_APP_PRIVATE_KEY=helper-bot:private-key
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
       - name: Get major version num and update tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           MAJOR=${VERSION%%.*}
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
           git tag -fa "${MAJOR}" -m 'chore: update major version tag [bot]'
           git push origin "${MAJOR}" --force


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows to enhance security and streamline processes. The most important changes involve switching to `pull_request_target`, adding id-token permissions, and using GitHub App tokens for authentication.

Security and permissions updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-R3): Changed the event trigger from `pull_request` to `pull_request_target` to improve security.
* [`.github/workflows/update-changelog.yml`](diffhunk://#diff-15d44bf84a03bd4b62871c8cfe5cd7b6298ae5c033a36cee56e357f74199449aR11): Added `id-token: write` permission to the `update_changelog` job to enable secure access to GitHub tokens.

Workflow improvements:

* [`.github/workflows/update-changelog.yml`](diffhunk://#diff-15d44bf84a03bd4b62871c8cfe5cd7b6298ae5c033a36cee56e357f74199449aR59-R81): Automated the merge of changelog update PRs by adding `gh pr merge --auto --squash` command.
* [`.github/workflows/update-changelog.yml`](diffhunk://#diff-15d44bf84a03bd4b62871c8cfe5cd7b6298ae5c033a36cee56e357f74199449aR59-R81): Integrated steps to fetch and use GitHub App tokens for approving and merging PRs, replacing the previous method of using repository secrets.
* [`.github/workflows/update-major-release-tag.yml`](diffhunk://#diff-f56893468a8310fd15400e5010f49650335438bc43e1262a3f21649eb6e33593R14-R40): Updated the major release tag workflow to use GitHub App tokens for authentication and configured user details dynamically.