### PR TITLE
Update readme - replace `tibdex/github-app-token` with `create-github-app-token`

### DIFF
--- a/docs/README.tmpl
+++ b/docs/README.tmpl
@@ -28,12 +28,11 @@ instance, if you create a branch via `git checkout -b my-test-branch` in one of 
 ### Example: Using a GitHub App Installation Token
 
 ```yaml
-  - uses: tibdex/github-app-token@v1
+  - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
     id: get_installation_token
     with:
-      app_id: ${{ secrets.GITHUB_APP_ID }}
-      installation_id: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
-      private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+      client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+      private-key: ${{ vars.GITHUB_APP_PRIVATE_KEY }}
 
   - name: Commit changes
     uses: grafana/github-api-commit-action@$TAG_HASH # $TAG


### PR DESCRIPTION
[tibdex/github-app-token](https://github.com/tibdex/github-app-token) was deprecated last year in favor [create-github-app-token](https://github.com/actions/create-github-app-token) 