### PR TITLE
ci: add cleanup-branches workflow (dry-run)

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,18 @@
+name: Clean up orphaned branches
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cleanup-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.2.1
+        with:
+          dry-run: "true"
+

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -11,8 +11,10 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.2.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1
         with:
           dry-run: "true"
 

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -12,8 +12,6 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1
         with:
           dry-run: "true"


### PR DESCRIPTION
Adds the [cleanup-branches](https://github.com/grafana/shared-workflows/tree/main/actions/cleanup-branches) workflow from shared-workflows in **dry-run mode**.

This will run weekly (Monday 9am UTC) and print which branches _would_ be deleted without actually deleting them. Check the workflow run output to verify, then set `dry-run: false` to enable.

Branches are eligible for cleanup if they:
- Are not in an open PR
- Are not protected
- Have not been updated in the last 3 months